### PR TITLE
Fix descriptor clause end index in canonicalizer

### DIFF
--- a/services/canonicalizer.py
+++ b/services/canonicalizer.py
@@ -31,7 +31,8 @@ class Canonicalizer:
             root = root.head
 
         clause_tokens = list(root.subtree)
-        clause_end = len(sent_doc)
+        # use document-level indices for end-of-sentence
+        clause_end = sent_doc.end
         for token in clause_tokens:
             if token.dep_ == "cc" and token.text.lower() in {"and", "but"}:
                 clause_end = token.i


### PR DESCRIPTION
## Summary
- fix clause end calculation when extracting descriptors

## Testing
- `python -m py_compile services/canonicalizer.py`
