### PR TITLE
Fix descriptor extraction index

### DIFF
--- a/services/canonicalizer.py
+++ b/services/canonicalizer.py
@@ -31,7 +31,7 @@ class Canonicalizer:
             root = root.head
 
         clause_tokens = list(root.subtree)
-        clause_end = len(sent_doc)
+        clause_end = sent_doc.end
         for token in clause_tokens:
             if token.dep_ == "cc" and token.text.lower() in {"and", "but"}:
                 clause_end = token.i

--- a/tests/test_descriptor_extraction.py
+++ b/tests/test_descriptor_extraction.py
@@ -1,0 +1,16 @@
+import pytest
+
+spacy = pytest.importorskip("spacy")
+from services.canonicalizer import Canonicalizer
+
+
+def test_extract_descriptors_no_conjunction():
+    nlp = spacy.load("en_core_web_sm")
+    canon = Canonicalizer.__new__(Canonicalizer)
+    text = "This is a test. The graphics are absolutely amazing."
+    doc = nlp(text)
+    match_token = next(t for t in doc if t.text.lower() == "graphics")
+    match_span = doc[match_token.i : match_token.i + 1]
+    sent = match_span.sent
+    result = canon._extract_descriptors(sent, match_span)
+    assert result == "absolutely amazing"


### PR DESCRIPTION
## Summary
- fix document index bug in `_extract_descriptors`
- add regression test for descriptor extraction without conjunctions

## Testing
- `pytest -q`